### PR TITLE
fix: make sure autogenerated file is ignored for linting issues

### DIFF
--- a/embedded_config/lib/embedded_config.dart
+++ b/embedded_config/lib/embedded_config.dart
@@ -13,5 +13,9 @@ import 'src/config_generator.dart';
 /// a part file will be emitted with the extension `.embedded.dart`
 /// in the same directory.
 Builder configBuilder(BuilderOptions options) {
-  return PartBuilder([ConfigGenerator(options.config)], '.embedded.dart');
+  return PartBuilder(
+    [ConfigGenerator(options.config)],
+    '.embedded.dart',
+    header: defaultFileHeader + '\n\n' + '// ignore_for_file: unnecessary_const\n',
+  );
 }


### PR DESCRIPTION
Lemme know how you want to handle changelog/version with the other PR

Adds linting header to generated files so default linting rules don't spam out unncessary const.
